### PR TITLE
[Fix] broken css in mobile auth form and introduce sub form

### DIFF
--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -55,7 +55,7 @@ const ErrorWrapper = styled.div`
 
 const InputWrapper = styled.input`
   ${mq({
-    height: ['auto', '40px'],
+    height: ['30px', '40px'],
     width: ['45vw', '400px'],
     padding: ['1vw 12px', '8px 12px'],
   })};
@@ -107,7 +107,7 @@ const SpaceBlock = styled.div`
 
 const StyledButton = styled(Button)`
   ${mq({
-    height: ['100%', '40px'],
+    height: ['3.2vh', '40px'],
   })};
   border: 2px solid ${palette.teal[5]};
   &:hover{

--- a/src/components/introduce/IntroduceForm.jsx
+++ b/src/components/introduce/IntroduceForm.jsx
@@ -5,9 +5,8 @@ import Moment from 'react-moment';
 import facepaint from 'facepaint';
 import styled from '@emotion/styled';
 
-import { authorizedUsersNumber, changeDateToTime } from '../../util/utils';
-
 import { INTRODUCE_FORM_TITLE } from '../../util/constants/constants';
+import { authorizedUsersNumber, changeDateToTime } from '../../util/utils';
 
 import Tags from '../common/Tags';
 import palette from '../../styles/palette';
@@ -49,12 +48,9 @@ const ModeratorWrapper = styled.div`
   font-weight: bold;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 1.5rem;
   color: ${palette.gray[6]};
-
-  span {
-    margin-right: 1rem;
-  }
 
   time {
   ${mq({
@@ -110,9 +106,9 @@ const IntroduceForm = ({
   return (
     <>
       <ModeratorWrapper>
-        <span>
-          {`🙋‍♂️ ${moderatorId}`}
-        </span>
+        <div>
+          {`🙋‍♂️${moderatorId}`}
+        </div>
         <Moment interval={0} format="YYYY년 MM월 DD일">{changeDateToTime(createDate)}</Moment>
       </ModeratorWrapper>
       <IntroduceReferenceWrapper>


### PR DESCRIPTION
- 회원가입과 로그인에 대한 css가 모바일에서 꺠지는 현상 수정
- 스터디 소개 페이지의 sub title이 밑으로 내려가는 현상 수정