### PR TITLE
[UI] 메인 페이지에 Dark Theme을 적용하라

### DIFF
--- a/src/components/base/DropDown.jsx
+++ b/src/components/base/DropDown.jsx
@@ -14,7 +14,7 @@ const DropDownWrapper = styled.div`
     position: relative;
     z-index: 5;
     width: 12rem;
-    background: white;
+    background: ${({ theme }) => theme.dropDownColor[1]};
     box-shadow: rgb(0 0 0 / 20%) 0px 0px 8px;
   }
 `;
@@ -28,15 +28,15 @@ const MenuContent = styled.div`
   transition: background-color .2s;
   
   &:hover {
-    background: ${palette.gray[2]};
+    background: ${({ theme }) => theme.dropDownColor[2]};
   }
 
   &.user-id {
     cursor: unset;
-    background: #DCE2F0;
+    background: ${({ theme }) => theme.dropDownColor[0]};
 
     &:hover{
-      background: #DCE2F0;
+      background: ${({ theme }) => theme.dropDownColor[0]};
     }
   }
 `;

--- a/src/components/base/DropDown.test.jsx
+++ b/src/components/base/DropDown.test.jsx
@@ -3,16 +3,19 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import DropDown from './DropDown';
+import MockTheme from '../common/test/MockTheme';
 
 describe('DropDown', () => {
   const handleClick = jest.fn();
 
   const renderDropDown = (visible) => render((
-    <DropDown
-      user="test"
-      visible={visible}
-      onLogout={handleClick}
-    />
+    <MockTheme>
+      <DropDown
+        user="test"
+        visible={visible}
+        onLogout={handleClick}
+      />
+    </MockTheme>
   ));
 
   context('Is Visible', () => {

--- a/src/components/base/Header.jsx
+++ b/src/components/base/Header.jsx
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 
 import mq from '../../styles/responsive';
 import Button from '../../styles/Button';
-import palette from '../../styles/palette';
 import AppBlock from '../../styles/AppBlock';
 
 import { LOGIN, REGISTER } from '../../util/constants/constants';
@@ -17,8 +16,8 @@ const HeaderWrapper = styled.div`
   position: fixed;
   width: 100%;
   z-index: 100;
-  box-shadow: 0px 2px 4px ${palette.gray[4]};
-  background: ${palette.gray[1]};
+  box-shadow: 0px 2px 4px ${({ theme }) => theme.headShadowColor};
+  background: ${({ theme }) => theme.subBaseTone[0]};
 `;
 
 const Wrapper = styled(AppBlock)`

--- a/src/components/base/Header.jsx
+++ b/src/components/base/Header.jsx
@@ -5,11 +5,11 @@ import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import mq from '../../styles/responsive';
-import Button from '../../styles/Button';
-import AppBlock from '../../styles/AppBlock';
 
 import { LOGIN, REGISTER } from '../../util/constants/constants';
 
+import Button from '../../styles/Button';
+import AppBlock from '../../styles/AppBlock';
 import UserHeaderStatus from './UserHeaderStatus';
 
 const HeaderWrapper = styled.div`

--- a/src/components/base/Header.test.jsx
+++ b/src/components/base/Header.test.jsx
@@ -7,6 +7,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { Context as ResponsiveContext } from 'react-responsive';
 
 import Header from './Header';
+import MockTheme from '../common/test/MockTheme';
 
 describe('Header', () => {
   beforeEach(() => {
@@ -16,14 +17,16 @@ describe('Header', () => {
   const handleClick = jest.fn();
 
   const renderHeader = ({ user, width = 700 }) => render((
-    <MemoryRouter>
-      <ResponsiveContext.Provider value={{ width }}>
-        <Header
-          user={user}
-          onLogout={handleClick}
-        />
-      </ResponsiveContext.Provider>
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <ResponsiveContext.Provider value={{ width }}>
+          <Header
+            user={user}
+            onLogout={handleClick}
+          />
+        </ResponsiveContext.Provider>
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   context('with user', () => {

--- a/src/components/base/UserHeaderStatus.test.jsx
+++ b/src/components/base/UserHeaderStatus.test.jsx
@@ -5,17 +5,20 @@ import { render, fireEvent } from '@testing-library/react';
 import { Context as ResponsiveContext } from 'react-responsive';
 
 import UserHeaderStatus from './UserHeaderStatus';
+import MockTheme from '../common/test/MockTheme';
 
 describe('UserHeaderStatus', () => {
   const handleClick = jest.fn();
 
   const renderUserHeaderStatus = (width) => render((
-    <ResponsiveContext.Provider value={{ width }}>
-      <UserHeaderStatus
-        user={given.user}
-        onClick={handleClick}
-      />
-    </ResponsiveContext.Provider>
+    <MockTheme>
+      <ResponsiveContext.Provider value={{ width }}>
+        <UserHeaderStatus
+          user={given.user}
+          onClick={handleClick}
+        />
+      </ResponsiveContext.Provider>
+    </MockTheme>
   ));
 
   context('Is mobile Screen', () => {

--- a/src/components/common/Tags.jsx
+++ b/src/components/common/Tags.jsx
@@ -26,7 +26,7 @@ const TagsWrapper = styled.div`
   `};
 `;
 
-const TagStyledWrapper = ({ div }) => css`
+const TagStyledWrapper = ({ div, theme }) => css`
   ${mq({
     fontSize: ['.7rem', '.8rem'],
     padding: ['0 .6rem', '0 .6rem'],
@@ -38,7 +38,7 @@ const TagStyledWrapper = ({ div }) => css`
   margin: .2rem;
   border-radius: .8em;
   color: ${palette.teal[7]};
-  background:${palette.gray[2]};
+  background: ${theme.tagBackGround[1]};
   transition: color .2s;
 
   &:hover {
@@ -77,6 +77,10 @@ const TagStyledDiv = styled.div`
 `;
 const TagStyledLink = styled(Link)`
   ${TagStyledWrapper}
+
+  ${({ type, theme }) => type && type === 'main' && css`
+    background: ${theme.tagBackGround[0]};
+  `};
 `;
 
 const Tags = ({ tags, type, onRemove }) => {
@@ -113,6 +117,7 @@ const Tags = ({ tags, type, onRemove }) => {
       {tags.map((tag) => (
         <TagStyledLink
           key={tag}
+          type={type}
           to={`/?tag=${tag}`}
         >
           {`#${tag}`}

--- a/src/components/common/Tags.test.jsx
+++ b/src/components/common/Tags.test.jsx
@@ -5,15 +5,18 @@ import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 
 import Tags from './Tags';
+import MockTheme from './test/MockTheme';
 
 describe('Tags', () => {
   const renderTags = ({ tags, type }) => render((
-    <MemoryRouter>
-      <Tags
-        type={type}
-        tags={tags}
-      />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <Tags
+          type={type}
+          tags={tags}
+        />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   context('with tags', () => {

--- a/src/components/common/test/MockTheme.jsx
+++ b/src/components/common/test/MockTheme.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { ThemeProvider } from '@emotion/react';
+
+import { lightTheme } from '../../../styles/theme';
+
+function MockTheme({ children }) {
+  return (
+    <ThemeProvider theme={lightTheme}>
+      {children}
+    </ThemeProvider>
+  );
+}
+
+export default MockTheme;

--- a/src/components/introduce/IntroduceForm.test.jsx
+++ b/src/components/introduce/IntroduceForm.test.jsx
@@ -9,6 +9,7 @@ import { fireEvent, render } from '@testing-library/react';
 import IntroduceForm from './IntroduceForm';
 
 import STUDY_GROUP from '../../../fixtures/study-group';
+import MockTheme from '../common/test/MockTheme';
 
 describe('IntroduceForm', () => {
   const handleRemove = jest.fn();
@@ -16,16 +17,18 @@ describe('IntroduceForm', () => {
   const renderIntroduceForm = ({
     group, time, user = 'user2', width = 830,
   }) => render((
-    <ResponsiveContext.Provider value={{ width }}>
-      <MemoryRouter>
-        <IntroduceForm
-          user={user}
-          group={group}
-          realTime={time}
-          onRemove={handleRemove}
-        />
-      </MemoryRouter>
-    </ResponsiveContext.Provider>
+    <MockTheme>
+      <ResponsiveContext.Provider value={{ width }}>
+        <MemoryRouter>
+          <IntroduceForm
+            user={user}
+            group={group}
+            realTime={time}
+            onRemove={handleRemove}
+          />
+        </MemoryRouter>
+      </ResponsiveContext.Provider>
+    </MockTheme>
   ));
 
   context('When the screen view is greater than 820px', () => {

--- a/src/components/introduce/IntroduceForm.test.jsx
+++ b/src/components/introduce/IntroduceForm.test.jsx
@@ -6,9 +6,9 @@ import { Context as ResponsiveContext } from 'react-responsive';
 
 import { fireEvent, render } from '@testing-library/react';
 
-import IntroduceForm from './IntroduceForm';
-
 import STUDY_GROUP from '../../../fixtures/study-group';
+
+import IntroduceForm from './IntroduceForm';
 import MockTheme from '../common/test/MockTheme';
 
 describe('IntroduceForm', () => {

--- a/src/components/main/StudyGroup.jsx
+++ b/src/components/main/StudyGroup.jsx
@@ -25,9 +25,9 @@ const StudyGroupWrapper = styled.div`
   flex-direction: column;
   overflow: hidden;
   border-radius: 4px;
-  border: 2px solid ${palette.gray[4]};
+  border: 2px solid ${({ theme }) => theme.borderTone[0]};
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 16px 0px;
-  background: #f5f5f5;
+  background: ${({ theme }) => theme.subBaseTone[2]};
   transition-duration: 0.25s, 0.25s;
   transition-timing-function: ease-in, ease-in;
   transition-delay: initial, initial;
@@ -51,17 +51,12 @@ const HeaderLink = styled(Link)`
     margin: 0px 0px 0.25rem;
     line-height: 1.5;
     overflow: hidden;
-    color: ${palette.gray[8]};
+    transition: color .25s;
+    color: ${({ theme }) => theme.fontColor[0]};
 
     &:hover {
-      color: ${palette.gray[6]};
+      color: ${({ theme }) => theme.hoverFontColor[0]};
     }
-  }
-`;
-
-const ContentLink = styled(Link)`
-  &:hover {
-    color: ${palette.gray[6]};
   }
 `;
 
@@ -71,7 +66,7 @@ const StudyInfoWrapper = styled.div`
   flex-direction: column;
 
   .moderator {
-    color: ${palette.gray[5]};
+    color: ${({ theme }) => theme.fontColor[2]};
     margin: 1rem 0;
     display: flex;
     flex-direction: row;
@@ -84,7 +79,7 @@ const StudyInfoWrapper = styled.div`
   }
 
   .apply-status {
-    color: ${palette.gray[7]};
+    color: ${({ theme }) => theme.fontColor[3]};
   }
 
   .date-time-change {
@@ -104,17 +99,22 @@ const StudyContentWrapper = styled.div`
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
-    word-break: break-word;
+    word-break: break-all;
     overflow-wrap: break-word;
     line-height: 1.5;
     height: 3.3rem;
     overflow: hidden;
-    color: ${palette.gray[7]};
+    transition: color .3s;
+    color: ${({ theme }) => theme.fontColor[1]};
+
+    &:hover {
+      color: ${({ theme }) => theme.hoverFontColor[1]};
+    }
   }
 `;
 
 const ApplyEndDateWrapper = styled.div`
-  color: ${palette.gray[7]};
+  color: ${({ theme }) => theme.fontColor[3]};
   padding-bottom: 1rem;
   border-bottom: 1px solid ${palette.gray[4]};
 `;
@@ -142,9 +142,9 @@ const StudyGroup = ({ group, realTime }) => {
       </HeaderLink>
       <StudyContentWrapper>
         <p>
-          <ContentLink to={`/introduce/${id}`}>
+          <Link to={`/introduce/${id}`}>
             {removeHtml(contents)}
-          </ContentLink>
+          </Link>
         </p>
       </StudyContentWrapper>
       <StudyInfoWrapper>

--- a/src/components/main/StudyGroup.test.jsx
+++ b/src/components/main/StudyGroup.test.jsx
@@ -4,18 +4,22 @@ import { render } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import StudyGroup from './StudyGroup';
 import { tomorrow } from '../../util/utils';
+
+import StudyGroup from './StudyGroup';
+import MockTheme from '../common/test/MockTheme';
 
 const isCheckOverTen = (calendar) => (calendar < 10 ? '0' : '');
 
 describe('StudyGroup', () => {
   const renderStudyGroup = ({ group }) => render((
-    <MemoryRouter>
-      <StudyGroup
-        group={group}
-      />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <StudyGroup
+          group={group}
+        />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   describe('renders study group text contents', () => {

--- a/src/components/main/StudyGroups.test.jsx
+++ b/src/components/main/StudyGroups.test.jsx
@@ -6,9 +6,9 @@ import { Context as ResponsiveContext } from 'react-responsive';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import StudyGroups from './StudyGroups';
-
 import STUDY_GROUPS from '../../../fixtures/study-groups';
+
+import StudyGroups from './StudyGroups';
 import MockTheme from '../common/test/MockTheme';
 
 describe('StudyGroups', () => {

--- a/src/components/main/StudyGroups.test.jsx
+++ b/src/components/main/StudyGroups.test.jsx
@@ -9,21 +9,24 @@ import { MemoryRouter } from 'react-router-dom';
 import StudyGroups from './StudyGroups';
 
 import STUDY_GROUPS from '../../../fixtures/study-groups';
+import MockTheme from '../common/test/MockTheme';
 
 describe('StudyGroups', () => {
   const handleThemeChange = jest.fn();
 
   const renderStudyGroups = ({ groups, width = 700, user = 'test' }) => render((
-    <ResponsiveContext.Provider value={{ width }}>
-      <MemoryRouter>
-        <StudyGroups
-          user={user}
-          theme={false}
-          groups={groups}
-          onChangeTheme={handleThemeChange}
-        />
-      </MemoryRouter>
-    </ResponsiveContext.Provider>
+    <MockTheme>
+      <ResponsiveContext.Provider value={{ width }}>
+        <MemoryRouter>
+          <StudyGroups
+            user={user}
+            theme={false}
+            groups={groups}
+            onChangeTheme={handleThemeChange}
+          />
+        </MemoryRouter>
+      </ResponsiveContext.Provider>
+    </MockTheme>
   ));
 
   context('When desktop screen', () => {

--- a/src/components/write/TagList.test.jsx
+++ b/src/components/write/TagList.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import TagList from './TagList';
+import MockTheme from '../common/test/MockTheme';
 
 describe('TagList', () => {
   const handleRemove = jest.fn();
@@ -12,10 +13,12 @@ describe('TagList', () => {
   });
 
   const renderTagList = (tags) => render((
-    <TagList
-      tags={tags}
-      onRemove={handleRemove}
-    />
+    <MockTheme>
+      <TagList
+        tags={tags}
+        onRemove={handleRemove}
+      />
+    </MockTheme>
   ));
 
   context('without tags', () => {

--- a/src/components/write/TagsForm.test.jsx
+++ b/src/components/write/TagsForm.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import TagsForm from './TagsForm';
+import MockTheme from '../common/test/MockTheme';
 
 describe('TagsForm', () => {
   const handleChange = jest.fn();
@@ -12,10 +13,12 @@ describe('TagsForm', () => {
   });
 
   const renderTagsForm = (tags) => render((
-    <TagsForm
-      tags={tags}
-      onChange={handleChange}
-    />
+    <MockTheme>
+      <TagsForm
+        tags={tags}
+        onChange={handleChange}
+      />
+    </MockTheme>
   ));
 
   describe('render Tag Form Container contents text', () => {

--- a/src/containers/base/HeaderContainer.test.jsx
+++ b/src/containers/base/HeaderContainer.test.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 
 import HeaderContainer from './HeaderContainer';
+import MockTheme from '../../components/common/test/MockTheme';
 
 describe('HeaderContainer', () => {
   const dispatch = jest.fn();
@@ -23,9 +24,11 @@ describe('HeaderContainer', () => {
   });
 
   const renderHeaderContainer = () => render((
-    <MemoryRouter>
-      <HeaderContainer />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <HeaderContainer />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   context('with user', () => {

--- a/src/containers/groups/StudyGroupsContainer.test.jsx
+++ b/src/containers/groups/StudyGroupsContainer.test.jsx
@@ -10,6 +10,7 @@ import { twoSecondsLater } from '../../util/utils';
 import studyGroup from '../../../fixtures/study-group';
 
 import StudyGroupsContainer from './StudyGroupsContainer';
+import MockTheme from '../../components/common/test/MockTheme';
 
 describe('StudyGroupsContainer', () => {
   const dispatch = jest.fn();
@@ -39,9 +40,11 @@ describe('StudyGroupsContainer', () => {
   });
 
   const renderStudyGroupsContainer = () => render((
-    <MemoryRouter>
-      <StudyGroupsContainer />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <StudyGroupsContainer />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   context('with groups', () => {

--- a/src/containers/introduce/IntroduceFormContainer.test.jsx
+++ b/src/containers/introduce/IntroduceFormContainer.test.jsx
@@ -9,6 +9,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { twoSecondsLater } from '../../util/utils';
 
 import IntroduceFormContainer from './IntroduceFormContainer';
+import MockTheme from '../../components/common/test/MockTheme';
 
 const mockPush = jest.fn();
 
@@ -46,9 +47,11 @@ describe('IntroduceFormContainer', () => {
   });
 
   const renderIntroduceFormContainer = () => render((
-    <MemoryRouter>
-      <IntroduceFormContainer />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter>
+        <IntroduceFormContainer />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   const group = {

--- a/src/containers/write/TagsFormContainer.test.jsx
+++ b/src/containers/write/TagsFormContainer.test.jsx
@@ -5,6 +5,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import TagsFormContainer from './TagsFormContainer';
+import MockTheme from '../../components/common/test/MockTheme';
 
 describe('TagsFormContainer', () => {
   const dispatch = jest.fn();
@@ -24,7 +25,9 @@ describe('TagsFormContainer', () => {
   });
 
   const renderTagsFormContainer = () => render((
-    <TagsFormContainer />
+    <MockTheme>
+      <TagsFormContainer />
+    </MockTheme>
   ));
 
   describe('render Tag Form Container contents text', () => {

--- a/src/pages/IntroducePage.test.jsx
+++ b/src/pages/IntroducePage.test.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { render } from '@testing-library/react';
 
 import IntroducePage from './IntroducePage';
+import MockTheme from '../components/common/test/MockTheme';
 
 describe('IntroducePage', () => {
   const dispatch = jest.fn();
@@ -48,9 +49,11 @@ describe('IntroducePage', () => {
       const params = { id: '1' };
 
       const { container } = render((
-        <MemoryRouter>
-          <IntroducePage params={params} />
-        </MemoryRouter>
+        <MockTheme>
+          <MemoryRouter>
+            <IntroducePage params={params} />
+          </MemoryRouter>
+        </MockTheme>
       ));
 
       expect(dispatch).toBeCalledTimes(1);
@@ -61,11 +64,13 @@ describe('IntroducePage', () => {
 
   context('without params props', () => {
     it('renders title', () => {
-      const { container } = render(
-        <MemoryRouter initialEntries={['/introduce/1']}>
-          <IntroducePage />
-        </MemoryRouter>,
-      );
+      const { container } = render((
+        <MockTheme>
+          <MemoryRouter initialEntries={['/introduce/1']}>
+            <IntroducePage />
+          </MemoryRouter>
+        </MockTheme>
+      ));
 
       expect(dispatch).toBeCalledTimes(1);
 

--- a/src/pages/MainPage.test.jsx
+++ b/src/pages/MainPage.test.jsx
@@ -6,8 +6,10 @@ import { render } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import MainPage from './MainPage';
 import STUDY_GROUPS from '../../fixtures/study-groups';
+
+import MainPage from './MainPage';
+import MockTheme from '../components/common/test/MockTheme';
 
 describe('MainPage', () => {
   const dispatch = jest.fn();
@@ -31,9 +33,11 @@ describe('MainPage', () => {
   });
 
   const renderMainPage = () => render((
-    <MemoryRouter initialEntries={['/?tag=JavaScript']}>
-      <MainPage />
-    </MemoryRouter>
+    <MockTheme>
+      <MemoryRouter initialEntries={['/?tag=JavaScript']}>
+        <MainPage />
+      </MemoryRouter>
+    </MockTheme>
   ));
 
   describe('renders Main Page text contents', () => {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,11 +1,67 @@
 export const lightTheme = {
   baseTone: '#fff',
+  subBaseTone: [
+    '#f1f3f5',
+    '#FFFFFF',
+    '#f5f5f5',
+  ],
+  borderTone: [
+    '#ced4da',
+  ],
   baseShadow: '0 0 0.1px rgb(0 0 0 / 30%);',
   baseFont: '#212529',
+  headShadowColor: '#ced4da',
+  dropDownColor: [
+    '#DCE2F0',
+    '#FFFFFF',
+    '#e9ecef',
+  ],
+  fontColor: [
+    '#343a40',
+    '#495057',
+    '#adb5bd',
+    '#495057',
+  ],
+  hoverFontColor: [
+    '#868e96',
+    '#868e96',
+  ],
+  tagBackGround: [
+    '#e9ecef',
+    '#e9ecef',
+  ],
 };
 
 export const darkTheme = {
   baseTone: '#282c35',
+  subBaseTone: [
+    '#50555f',
+    '#7c818c',
+    '#50555f',
+  ],
+  borderTone: [
+    '#495057',
+  ],
   baseShadow: '0 0 0.1px hsl(0deg 0% 100% / 30%)',
   baseFont: '#eee',
+  headShadowColor: '#495057',
+  dropDownColor: [
+    '#7c818c',
+    '#abb0bc',
+    '#ced4da',
+  ],
+  fontColor: [
+    '#ced4da',
+    '#ced4da',
+    '#a4b0be',
+    '#a4b0be',
+  ],
+  hoverFontColor: [
+    '#a4b0be',
+    '#a4b0be',
+  ],
+  tagBackGround: [
+    '#282c35',
+    '#50555f',
+  ],
 };


### PR DESCRIPTION
- 메인 페이지의 스터디 리스트, 헤더에 dark theme을 적용
- ThemeProvider로 인해 테스트가 꺠지는 것을 방지하기 위해 MockTheme을 구현
- 관련된 테스트에 MockTheme을 적용