### PR TITLE
[Remove] 불필요한 npm dependencies를 삭제하라

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,6 @@
         "react-toggle": "^4.1.2",
         "react-use": "^15.3.4",
         "redux": "^4.0.5",
-        "redux-devtools-extension": "^2.13.8",
-        "redux-logger": "^3.0.6",
         "sanitize-html": "^2.2.0"
       },
       "devDependencies": {
@@ -76,7 +74,7 @@
         "jest": "^26.6.3",
         "jest-plugin-context": "^2.9.0",
         "mini-css-extract-plugin": "^1.4.1",
-        "optimize-css-assets-webpack-plugin": "^6.0.0",
+        "optimize-css-assets-webpack-plugin": "^6.0.1",
         "playwright": "^1.11.1",
         "redux-mock-store": "^1.5.4",
         "start-server-and-test": "^1.11.5",
@@ -7402,11 +7400,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
-    },
     "node_modules/deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -8143,9 +8136,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -16073,9 +16066,9 @@
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-6.0.0.tgz",
-      "integrity": "sha512-XKVxJuCBSslP1Eyuf1uVtZT3Pkp6jEIkmg7BMcNU/pq6XAnDXTINkYFWmiQWt8+j//FO4dIDd4v+gn0m5VWJIw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-6.0.1.tgz",
+      "integrity": "sha512-BshV2UZPfggZLdUfN3zFBbG4sl/DynUI+YCB6fRRDWaqO2OiWN8GPcp4Y0/fEV6B3k9Hzyk3czve3V/8B/SzKQ==",
       "dev": true,
       "dependencies": {
         "cssnano": "^5.0.2",
@@ -17115,9 +17108,9 @@
       }
     },
     "node_modules/postcss-normalize-url/node_modules/normalize-url": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
-      "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -18410,19 +18403,6 @@
       "dependencies": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
-      }
-    },
-    "node_modules/redux-devtools-extension": {
-      "version": "2.13.8",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
-      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
-    },
-    "node_modules/redux-logger": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
-      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
-      "dependencies": {
-        "deep-diff": "^0.3.5"
       }
     },
     "node_modules/redux-mock-store": {
@@ -22155,9 +22135,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
-      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
       "dev": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
@@ -22168,7 +22148,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.3.0",
+        "enhanced-resolve": "^4.5.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
@@ -22189,6 +22169,18 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-cli": {
@@ -29914,11 +29906,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
-    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -30550,9 +30537,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -36945,9 +36932,9 @@
       }
     },
     "optimize-css-assets-webpack-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-6.0.0.tgz",
-      "integrity": "sha512-XKVxJuCBSslP1Eyuf1uVtZT3Pkp6jEIkmg7BMcNU/pq6XAnDXTINkYFWmiQWt8+j//FO4dIDd4v+gn0m5VWJIw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-6.0.1.tgz",
+      "integrity": "sha512-BshV2UZPfggZLdUfN3zFBbG4sl/DynUI+YCB6fRRDWaqO2OiWN8GPcp4Y0/fEV6B3k9Hzyk3czve3V/8B/SzKQ==",
       "dev": true,
       "requires": {
         "cssnano": "^5.0.2",
@@ -37713,9 +37700,9 @@
       },
       "dependencies": {
         "normalize-url": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
-          "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
           "dev": true
         }
       }
@@ -38756,19 +38743,6 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
-      }
-    },
-    "redux-devtools-extension": {
-      "version": "2.13.8",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
-      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
-    },
-    "redux-logger": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
-      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
-      "requires": {
-        "deep-diff": "^0.3.5"
       }
     },
     "redux-mock-store": {
@@ -41897,9 +41871,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
-      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -41910,7 +41884,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.3.0",
+        "enhanced-resolve": "^4.5.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "react-toggle": "^4.1.2",
     "react-use": "^15.3.4",
     "redux": "^4.0.5",
-    "redux-devtools-extension": "^2.13.8",
-    "redux-logger": "^3.0.6",
     "sanitize-html": "^2.2.0"
   },
   "devDependencies": {
@@ -94,7 +92,7 @@
     "jest": "^26.6.3",
     "jest-plugin-context": "^2.9.0",
     "mini-css-extract-plugin": "^1.4.1",
-    "optimize-css-assets-webpack-plugin": "^6.0.0",
+    "optimize-css-assets-webpack-plugin": "^6.0.1",
     "playwright": "^1.11.1",
     "redux-mock-store": "^1.5.4",
     "start-server-and-test": "^1.11.5",

--- a/src/reducers/store.js
+++ b/src/reducers/store.js
@@ -1,9 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { composeWithDevTools } from 'redux-devtools-extension';
-import { createLogger } from 'redux-logger';
 
 import rootReducer from './rootSlice';
 
-const store = configureStore({ reducer: rootReducer }, composeWithDevTools(createLogger()));
+import { isDevLevel } from '../util/utils';
+
+const store = configureStore({
+  reducer: rootReducer,
+  devTools: isDevLevel(process.env.NODE_ENV),
+});
 
 export default store;

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -22,6 +22,14 @@ export const getTheme = (theme) => {
   return LIGHT;
 };
 
+export const isDevLevel = (env) => {
+  if (env === 'production') {
+    return false;
+  }
+
+  return true;
+};
+
 export const authorizedUsersNumber = (participants) => participants
   .filter(({ confirm }) => confirm && confirm === true)
   .length + 1;

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -8,6 +8,7 @@ import {
   formatGroup,
   getCommon,
   getTheme,
+  isDevLevel,
 } from './utils';
 
 test('getAuth', () => {
@@ -78,6 +79,24 @@ describe('getTheme', () => {
       const result = getTheme();
 
       expect(result).toBe(false);
+    });
+  });
+});
+
+describe('isDevLevel', () => {
+  context('With production', () => {
+    it('Should be return false', () => {
+      const result = isDevLevel('production');
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  context('Without production', () => {
+    it('Should be return true', () => {
+      const result = isDevLevel('development');
+
+      expect(result).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
- redux-toolkit에 내장되어있음에 따라 redux-devtools-extension, redux-logger를 삭제
- development level에만 devtools을 적용