### PR TITLE
[Refactoring] 전역으로 관리하던 불필요한 ReviewForm state를 걷어내라

### DIFF
--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { Link } from 'react-router-dom';
 
-import { useForm } from 'react-hook-form';
-
 import facepaint from 'facepaint';
 import styled from '@emotion/styled';
 
@@ -136,16 +134,16 @@ const StyledButton = styled(Button)`
   }
 `;
 
-const AuthForm = ({ type, onSubmit, error }) => {
-  const { register, handleSubmit } = useForm();
-
+const AuthForm = ({
+  type, onSubmit, register, error,
+}) => {
   const formType = FORM_TYPE[type];
 
   return (
     <AuthBlock>
       <AuthFormWrapper>
         <h2>{formType}</h2>
-        <FormWrapper onSubmit={handleSubmit(onSubmit)}>
+        <FormWrapper onSubmit={onSubmit}>
           <InputWrapper
             type="text"
             placeholder="이메일"

--- a/src/components/auth/AuthForm.test.jsx
+++ b/src/components/auth/AuthForm.test.jsx
@@ -9,9 +9,11 @@ import MockTheme from '../common/test/MockTheme';
 
 describe('AuthForm', () => {
   const handleSubmit = jest.fn();
+  const mockRegister = jest.fn();
 
   beforeEach(() => {
     handleSubmit.mockClear();
+    mockRegister.mockClear();
   });
 
   const renderAuthForm = ({ type, error = '' }) => render((
@@ -20,6 +22,7 @@ describe('AuthForm', () => {
         <AuthForm
           type={type}
           error={error}
+          register={mockRegister}
           onSubmit={handleSubmit}
         />
       </MemoryRouter>

--- a/src/components/introduce/ReviewForm.jsx
+++ b/src/components/introduce/ReviewForm.jsx
@@ -1,6 +1,4 @@
-import React, { useState, useCallback } from 'react';
-
-import _ from 'lodash';
+import React from 'react';
 
 import styled from '@emotion/styled';
 
@@ -8,14 +6,10 @@ import StarRatings from 'react-star-ratings';
 
 import { useMediaQuery } from 'react-responsive';
 
-import { STUDY_REVIEW_FORM } from '../../util/constants/constants';
-
 import mq from '../../styles/responsive';
 
 import Button from '../../styles/Button';
 import Textarea from '../../styles/Textarea';
-
-const { FORM_TITLE, REVIEW_SUBMIT } = STUDY_REVIEW_FORM;
 
 const StudyReviewFormWrapper = styled.div`
   ${mq({
@@ -61,31 +55,14 @@ const StudyReviewFormButton = styled(Button)`
   })};
 `;
 
-const isValidateAboutUser = (user, group) => {
-  const { participants, reviews } = group;
-
-  return !participants.some(({ id, confirm }) => id === user && confirm && confirm === true)
-    || reviews.some(({ id }) => id && id === user);
-};
-
 const ReviewForm = ({
-  group, user, fields, onChangeReview, onSubmit,
+  hasPermission, fields, onChange, onSubmit, error,
 }) => {
-  const [error, setError] = useState(false);
   const { rating, content } = fields;
 
   const isMobileScreen = useMediaQuery({ query: '(max-width: 450px)' });
 
-  const handleSubmit = useCallback(() => {
-    if (!_.trim(content)) {
-      setError(true);
-      return;
-    }
-
-    onSubmit();
-  }, [content]);
-
-  const handleChangeRating = (newRating, name) => onChangeReview({
+  const handleChangeRating = (newRating, name) => onChange({
     name,
     value: newRating,
   });
@@ -93,18 +70,17 @@ const ReviewForm = ({
   const handleChangeReview = (event) => {
     const { name, value } = event.target;
 
-    setError(false);
-    onChangeReview({ name, value });
+    onChange({ name, value });
   };
 
-  if (isValidateAboutUser(user, group)) {
+  if (!hasPermission) {
     return null;
   }
 
   return (
     <StudyReviewFormWrapper>
       <StudyReviewFormHeader>
-        <h2>{FORM_TITLE}</h2>
+        <h2>스터디 후기를 작성해주세요!</h2>
         <StarRatings
           rating={rating}
           starRatedColor="#ffc816"
@@ -128,9 +104,9 @@ const ReviewForm = ({
         />
         <StudyReviewFormButton
           success
-          onClick={handleSubmit}
+          onClick={onSubmit}
         >
-          {REVIEW_SUBMIT}
+          후기 등록하기
         </StudyReviewFormButton>
       </StudyReviewFormBody>
     </StudyReviewFormWrapper>

--- a/src/components/introduce/ReviewForm.test.jsx
+++ b/src/components/introduce/ReviewForm.test.jsx
@@ -18,16 +18,16 @@ describe('ReviewForm', () => {
   const reviewForm = { rating: 3, content: '' };
 
   const renderReviewForm = ({
-    group, user, fields = reviewForm, width = 700,
+    error, fields = reviewForm, width = 700, hasPermission,
   }) => render((
     <MockTheme>
       <ResponsiveContext.Provider value={{ width }}>
         <ReviewForm
-          user={user}
-          group={group}
+          error={error}
           fields={fields}
           onSubmit={handleSubmit}
-          onChangeReview={handleChange}
+          onChange={handleChange}
+          hasPermission={hasPermission}
         />
       </ResponsiveContext.Provider>
     </MockTheme>
@@ -36,12 +36,9 @@ describe('ReviewForm', () => {
   context('When Mobile Screen', () => {
     describe('When the user is approved applicant and applyEndDate is Deadline', () => {
       const settings = {
-        group: {
-          participants: [{ id: 'user1', confirm: true }],
-          reviews: [],
-        },
-        user: 'user1',
+        error: false,
         width: 400,
+        hasPermission: true,
       };
 
       it('renders study review form', () => {
@@ -53,102 +50,61 @@ describe('ReviewForm', () => {
   });
 
   context('When Desktop Screen', () => {
-    context('with user', () => {
-      context('When you have already written a review', () => {
+    context('Has Permission about write review', () => {
+      context('Has error', () => {
         const settings = {
-          group: {
-            participants: [{ id: 'user1', confirm: true }],
-            reviews: [{ id: 'user1', content: 'review' }],
-          },
-          user: 'user1',
+          error: true,
+          hasPermission: true,
         };
 
-        it('Should be nothing renders', () => {
-          const { container } = renderReviewForm(settings);
-          expect(container).toBeEmptyDOMElement();
+        it('should be textarea border color changes to red', () => {
+          const { getByPlaceholderText } = renderReviewForm(settings);
+
+          const textarea = getByPlaceholderText('후기를 입력해주세요!');
+
+          expect(textarea).toHaveStyle('border: 1px solid #ff8787');
         });
       });
 
-      context("When you didn't write a review", () => {
-        describe('When the user is approved applicant and applyEndDate is Deadline', () => {
-          const settings = {
-            group: {
-              participants: [{ id: 'user1', confirm: true }],
-              reviews: [],
+      context("Hasn't error", () => {
+        const settings = {
+          error: false,
+          hasPermission: true,
+        };
+
+        it('call event change review form', () => {
+          const { getByPlaceholderText } = renderReviewForm(settings);
+
+          const textarea = getByPlaceholderText('후기를 입력해주세요!');
+
+          fireEvent.change(textarea, {
+            target: {
+              name: 'content',
+              value: 'test',
             },
-            user: 'user1',
-          };
-
-          it('renders study review form', () => {
-            const { container } = renderReviewForm(settings);
-            expect(container).toHaveTextContent('스터디 후기를 작성해주세요!');
-          });
-          it('call event change review form', () => {
-            const { getByPlaceholderText } = renderReviewForm(settings);
-
-            const textarea = getByPlaceholderText('후기를 입력해주세요!');
-
-            fireEvent.change(textarea, {
-              target: {
-                name: 'content',
-                value: 'test',
-              },
-            });
-
-            expect(handleChange).toBeCalled();
           });
 
-          describe('When Click the "후기 등록하기" button', () => {
-            context('With review content', () => {
-              it('call event submit about review form', () => {
-                const { getByText } = renderReviewForm({
-                  ...settings,
-                  fields: { content: 'test', rating: 3 },
-                });
-
-                fireEvent.click(getByText('후기 등록하기'));
-
-                expect(handleSubmit).toBeCalled();
-              });
-            });
-
-            context('Without review content', () => {
-              it("doesn't call event submit about review form", () => {
-                const { getByText } = renderReviewForm(settings);
-
-                fireEvent.click(getByText('후기 등록하기'));
-
-                expect(handleSubmit).not.toBeCalled();
-              });
-            });
-          });
+          expect(handleChange).toBeCalled();
         });
 
-        describe('When the user is not approved applicant', () => {
-          it('nothing renders study review form', () => {
-            const { container } = renderReviewForm({
-              group: {
-                participants: [],
-                reviews: [],
-              },
-              user: 'user2',
-            });
+        it('call event submit about review form', () => {
+          const { getByText } = renderReviewForm(settings);
 
-            expect(container).toBeEmptyDOMElement();
-          });
+          fireEvent.click(getByText('후기 등록하기'));
+
+          expect(handleSubmit).toBeCalled();
         });
       });
     });
 
-    context('without user', () => {
-      it('nothing renders study review form', () => {
-        const { container } = renderReviewForm({
-          group: {
-            participants: [],
-            reviews: [],
-          },
-          user: null,
-        });
+    context("Hasn't Permission about write review", () => {
+      const settings = {
+        error: false,
+        hasPermission: false,
+      };
+
+      it('Should be nothing renders', () => {
+        const { container } = renderReviewForm(settings);
 
         expect(container).toBeEmptyDOMElement();
       });

--- a/src/containers/auth/LoginFormContainer.jsx
+++ b/src/containers/auth/LoginFormContainer.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useUnmount } from 'react-use';
+import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -21,6 +22,8 @@ const LoginFormContainer = () => {
 
   const user = useSelector(getAuth('user'));
   const authError = useSelector(getAuth('authError'));
+
+  const { register, handleSubmit, setValue } = useForm();
 
   const onSubmit = useCallback((formData) => {
     if (isNullFields(formData)) {
@@ -43,6 +46,7 @@ const LoginFormContainer = () => {
         FIREBASE_AUTH_ERROR_MESSAGE[authError]
         || FAILURE_LOGIN,
       );
+      setValue('password', '');
 
       return;
     }
@@ -58,7 +62,8 @@ const LoginFormContainer = () => {
     <AuthForm
       type="login"
       error={error}
-      onSubmit={onSubmit}
+      register={register}
+      onSubmit={handleSubmit(onSubmit)}
     />
   );
 };

--- a/src/containers/auth/RegisterFormContainer.jsx
+++ b/src/containers/auth/RegisterFormContainer.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useUnmount } from 'react-use';
+import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -23,6 +24,8 @@ const RegisterFormContainer = () => {
   const user = useSelector(getAuth('user'));
   const authError = useSelector(getAuth('authError'));
 
+  const { register, handleSubmit, setValue } = useForm();
+
   const onSubmit = useCallback((formData) => {
     const { userEmail, password, passwordConfirm } = formData;
 
@@ -32,6 +35,8 @@ const RegisterFormContainer = () => {
     }
 
     if (password !== passwordConfirm) {
+      setValue('password', '');
+      setValue('passwordConfirm', '');
       setError(NOT_MATCH_PASSWORD);
       return;
     }
@@ -69,7 +74,8 @@ const RegisterFormContainer = () => {
     <AuthForm
       type="register"
       error={error}
-      onSubmit={onSubmit}
+      register={register}
+      onSubmit={handleSubmit(onSubmit)}
     />
   );
 };

--- a/src/containers/auth/RegisterFormContainer.test.jsx
+++ b/src/containers/auth/RegisterFormContainer.test.jsx
@@ -135,6 +135,7 @@ describe('RegisterFormContainer', () => {
           });
 
           expect(dispatch).not.toBeCalled();
+          expect(getByPlaceholderText('비밀번호')).toHaveValue('');
           expect(container).toHaveTextContent('비밀번호가 일치하지 않습니다.');
         });
       });

--- a/src/containers/introduce/ReviewContainer.jsx
+++ b/src/containers/introduce/ReviewContainer.jsx
@@ -1,43 +1,72 @@
 import React, { useState, useCallback } from 'react';
 
+import _ from 'lodash';
+
 import { useInterval } from 'react-use';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
   getAuth, getGroup, isCheckedTimeStatus, changeDateToTime,
 } from '../../util/utils';
-import { changeStudyReviewFields, setStudyReview, deleteStudyReview } from '../../reducers/groupSlice';
+import { setStudyReview, deleteStudyReview } from '../../reducers/groupSlice';
 
 import SubTitle from '../../styles/SubTitle';
 
 import ReviewForm from '../../components/introduce/ReviewForm';
 import ReviewList from '../../components/introduce/ReviewList';
 
+const initFieldsState = {
+  rating: 3,
+  content: '',
+};
+
 const ReviewFormContainer = () => {
+  const [error, setError] = useState(false);
   const [realTime, setRealTime] = useState(Date.now());
+  const [reviewFields, setReviewFields] = useState(initFieldsState);
 
   const dispatch = useDispatch();
 
   const user = useSelector(getAuth('user'));
   const group = useSelector(getGroup('group'));
-  const studyReviewFields = useSelector(getGroup('studyReviewFields'));
 
   useInterval(() => setRealTime(Date.now()), 1000);
 
-  const onChangeReviewFields = useCallback(({ name, value }) => {
-    dispatch(changeStudyReviewFields({ name, value }));
-  }, [dispatch]);
+  const onChangeFields = useCallback(({ name, value }) => {
+    setError(false);
+
+    setReviewFields({
+      ...reviewFields,
+      [name]: value,
+    });
+  }, [reviewFields]);
 
   const onSubmitReview = useCallback(() => {
+    const { content } = reviewFields;
+
+    if (!_.trim(content)) {
+      setError(true);
+      return;
+    }
+
     dispatch(setStudyReview({
       id: user,
-      ...studyReviewFields,
+      ...reviewFields,
     }));
-  }, [dispatch, user, studyReviewFields]);
+
+    setReviewFields(initFieldsState);
+  }, [dispatch, user, reviewFields]);
 
   const onDeleteReview = useCallback((reviewId) => {
     dispatch(deleteStudyReview(reviewId));
   }, [dispatch]);
+
+  const hasPermissionAboutWriteReview = useCallback(() => {
+    const { participants, reviews } = group;
+
+    return !(!participants.some(({ id, confirm }) => id === user && confirm && confirm === true)
+      || reviews.some(({ id }) => id && id === user));
+  }, [group, user]);
 
   if (!group) {
     return null;
@@ -60,11 +89,11 @@ const ReviewFormContainer = () => {
     <>
       <SubTitle title="후기" />
       <ReviewForm
-        user={user}
-        group={group}
-        fields={studyReviewFields}
-        onChangeReview={onChangeReviewFields}
+        error={error}
+        fields={reviewFields}
+        onChange={onChangeFields}
         onSubmit={onSubmitReview}
+        hasPermission={hasPermissionAboutWriteReview()}
       />
       <ReviewList
         user={user}

--- a/src/reducers/groupSlice.js
+++ b/src/reducers/groupSlice.js
@@ -32,11 +32,6 @@ const applyInitialState = {
   wantToGet: '',
 };
 
-const studyReviewInitialState = {
-  rating: 3,
-  content: '',
-};
-
 const { actions, reducer } = createSlice({
   name: 'group',
   initialState: {
@@ -47,7 +42,6 @@ const { actions, reducer } = createSlice({
     originalArticleId: null,
     writeField: writeInitialState,
     applyFields: applyInitialState,
-    studyReviewFields: studyReviewInitialState,
   },
 
   reducers: {
@@ -126,19 +120,6 @@ const { actions, reducer } = createSlice({
       };
     },
 
-    changeStudyReviewFields(state, { payload: { name, value } }) {
-      return produce(state, (draft) => {
-        draft.studyReviewFields[name] = value;
-      });
-    },
-
-    clearStudyReviewFields(state) {
-      return {
-        ...state,
-        studyReviewFields: studyReviewInitialState,
-      };
-    },
-
     setGroupReview(state, { payload: review }) {
       return produce(state, (draft) => {
         draft.group.reviews.push({
@@ -160,8 +141,6 @@ export const {
   changeApplyFields,
   clearApplyFields,
   setOriginalArticle,
-  changeStudyReviewFields,
-  clearStudyReviewFields,
   setGroupReview,
 } = actions;
 
@@ -303,15 +282,13 @@ export const deleteGroup = (groupId) => async (dispatch) => {
 
 export const setStudyReview = (review) => async (dispatch, getState) => {
   const { groupReducer: { group } } = getState();
-  const { id } = group;
 
   await postUpdateStudyReview({
-    id,
+    groupId: group.id,
     review,
   });
 
   dispatch(setGroupReview(review));
-  dispatch(clearStudyReviewFields());
 };
 
 export const deleteStudyReview = (reviewId) => async (dispatch, getState) => {

--- a/src/reducers/groupSlice.test.js
+++ b/src/reducers/groupSlice.test.js
@@ -21,8 +21,6 @@ import reducer, {
   setOriginalArticle,
   editStudyGroup,
   setGroupError,
-  changeStudyReviewFields,
-  clearStudyReviewFields,
   setStudyReview,
   setGroupReview,
   deleteStudyReview,
@@ -62,10 +60,6 @@ describe('reducer', () => {
       applyFields: {
         reason: '',
         wantToGet: '',
-      },
-      studyReviewFields: {
-        rating: 3,
-        content: '',
       },
     };
 
@@ -232,42 +226,6 @@ describe('reducer', () => {
 
       expect(originalArticleId).toBe('1');
       expect(writeField.title).toBe('title');
-    });
-  });
-
-  describe('changeStudyReviewFields', () => {
-    it('changes a field of study review form', () => {
-      const initialState = {
-        studyReviewFields: {
-          rating: 3,
-          review: '',
-        },
-      };
-
-      const state = reducer(
-        initialState,
-        changeStudyReviewFields({ name: 'rating', value: 5 }),
-      );
-
-      expect(state.studyReviewFields.rating).toBe(5);
-    });
-  });
-
-  describe('clearStudyReviewFields', () => {
-    const initialState = {
-      studyReviewFields: {
-        rating: 5,
-        content: 'test',
-      },
-    };
-
-    it('clears fields of study review form', () => {
-      const state = reducer(initialState, clearStudyReviewFields());
-
-      const { studyReviewFields: { rating, content } } = state;
-
-      expect(rating).toBe(3);
-      expect(content).toBe('');
     });
   });
 
@@ -617,7 +575,7 @@ describe('async actions', () => {
       });
     });
 
-    it('dispatches setGroupReview and clearStudyReviewFields', async () => {
+    it('dispatches setGroupReview', async () => {
       await store.dispatch(setStudyReview({
         id: 'user',
         review: 'test',
@@ -633,9 +591,6 @@ describe('async actions', () => {
           review: 'test',
           id: 'user',
         },
-      });
-      expect(actions[1]).toEqual({
-        type: 'group/clearStudyReviewFields',
       });
     });
   });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -62,8 +62,8 @@ export const editPostStudyGroup = async ({
   });
 };
 
-export const postUpdateStudyReview = async ({ id, review }) => {
-  const group = db.collection('groups').doc(id);
+export const postUpdateStudyReview = async ({ groupId, review }) => {
+  const group = db.collection('groups').doc(groupId);
 
   await group.set({
     reviews: fireStore.FieldValue.arrayUnion({

--- a/src/util/constants/constants.js
+++ b/src/util/constants/constants.js
@@ -40,8 +40,3 @@ export const APPLY_STATUS = {
   REJECT: '승인 거절',
   COMPLETE: '신청 완료',
 };
-
-export const STUDY_REVIEW_FORM = {
-  FORM_TITLE: '스터디 후기를 작성해주세요!',
-  REVIEW_SUBMIT: '후기 등록하기',
-};


### PR DESCRIPTION
- AuthFomr 컴포넌트에 있던 useForm hook을 LoginContainer, RegisterContainer로 옮김
- 전역적으로 관리할 필요가 없던 ReviewForm fields state를 useState로 관리하도록 변경
- onChange Dispatch Action을 삭제
- View와 비즈니스 로직을 분리하도록 코드 리팩터링