### PR TITLE
[Refactoring] 스터디 신청서 폼에 react-hook-form을 적용하라

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,6 @@ module.exports = {
     'linebreak-style': 'off',
     'no-proto': 'off',
     'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['draft'] }],
-    'react/jsx-props-no-spreading': ['error', { exceptions: ['InputWrapper'] }],
+    'react/jsx-props-no-spreading': ['error', { exceptions: ['InputWrapper', 'Textarea'] }],
   },
 };

--- a/src/components/introduce/ApplicantViewButton.jsx
+++ b/src/components/introduce/ApplicantViewButton.jsx
@@ -6,10 +6,10 @@ import mq from '../../styles/responsive';
 
 import { changeDateToTime, isCheckedTimeStatus } from '../../util/utils';
 
-import ApplyStatusButton from './ApplyStatusButton';
-import ApplicationFormModal from './modals/ApplicationFormModal';
-import AskApplyCancelModal from './modals/AskApplyCancelModal';
 import AskLoginModal from './modals/AskLoginModal';
+import ApplyStatusButton from './ApplyStatusButton';
+import AskApplyCancelModal from './modals/AskApplyCancelModal';
+import ApplicationFormModal from './modals/ApplicationFormModal';
 
 const ParticipantsStatus = styled.div`
   ${mq({
@@ -24,27 +24,15 @@ const ParticipantsStatus = styled.div`
 `;
 
 const ApplicantViewButton = ({
-  group, onApply, user, realTime, onApplyCancel, onChangeApplyFields, applyFields, clearForm,
+  group, user, realTime, onApply, onApplyCancel,
 }) => {
+  const [modalForm, setModalForm] = useState(false);
   const [loginCheckModal, setLoginCheckModal] = useState(false);
   const [applyCancelModal, setApplyCancelModal] = useState(false);
-  const [modalForm, setModalForm] = useState(false);
 
   const { moderatorId, participants, applyEndDate } = group;
 
   const applyEndTime = changeDateToTime(applyEndDate);
-
-  const handleApplyCancelConfirmClick = () => {
-    setApplyCancelModal(true);
-  };
-
-  const handleLoginCheckCancel = () => {
-    setLoginCheckModal(false);
-  };
-
-  const handleApplyCancel = () => {
-    setApplyCancelModal(false);
-  };
 
   const handleApplyCancelConfirm = () => {
     setApplyCancelModal(false);
@@ -60,14 +48,9 @@ const ApplicantViewButton = ({
     setModalForm(true);
   };
 
-  const handleFormSubmit = () => {
+  const handleApplicationSubmit = (formData) => {
     setModalForm(false);
-    onApply(applyFields);
-  };
-
-  const handleFormCancel = () => {
-    setModalForm(false);
-    clearForm();
+    onApply(formData);
   };
 
   const isCheckedUserStatus = (applicant, userEmail) => applicant
@@ -89,26 +72,24 @@ const ApplicantViewButton = ({
         <ApplyStatusButton
           user={user}
           onApply={handleApply}
-          onCancel={handleApplyCancelConfirmClick}
+          onCancel={() => setApplyCancelModal(true)}
           userStatus={isCheckedUserStatus(participants, user)}
           timeStatus={isCheckedTimeStatus(status)}
         />
       </ParticipantsStatus>
       <AskLoginModal
         visible={loginCheckModal}
-        onCancel={handleLoginCheckCancel}
+        onCancel={() => setLoginCheckModal(false)}
       />
       <AskApplyCancelModal
         visible={applyCancelModal}
-        onCancel={handleApplyCancel}
+        onCancel={() => setApplyCancelModal(true)}
         onConfirm={handleApplyCancelConfirm}
       />
       <ApplicationFormModal
         visible={modalForm}
-        onCancel={handleFormCancel}
-        onConfirm={handleFormSubmit}
-        onChangeApply={onChangeApplyFields}
-        fields={applyFields}
+        onCancel={() => setModalForm(false)}
+        onSubmit={handleApplicationSubmit}
       />
     </>
   );

--- a/src/components/introduce/ApplicantViewButton.test.jsx
+++ b/src/components/introduce/ApplicantViewButton.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { act } from 'react-dom/test-utils';
 import { fireEvent, render } from '@testing-library/react';
 
 import STUDY_GROUP from '../../../fixtures/study-group';
@@ -10,7 +11,6 @@ import ApplicantViewButton from './ApplicantViewButton';
 describe('ApplicantViewButton', () => {
   const handleApply = jest.fn();
   const handleApplyCancel = jest.fn();
-  const handleClearForm = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,11 +21,9 @@ describe('ApplicantViewButton', () => {
       <ApplicantViewButton
         user={user}
         group={group}
-        applyFields={{ reason: 'reason', wantToGet: 'reason' }}
         realTime={time}
         onApply={handleApply}
         onApplyCancel={handleApplyCancel}
-        clearForm={handleClearForm}
       />
     </MockTheme>
   ));
@@ -70,7 +68,6 @@ describe('ApplicantViewButton', () => {
           expect(button).not.toBeNull();
 
           fireEvent.click(button);
-
           fireEvent.click(getByText('확인'));
 
           expect(handleApplyCancel).toBeCalled();
@@ -86,7 +83,6 @@ describe('ApplicantViewButton', () => {
           expect(button).not.toBeNull();
 
           fireEvent.click(button);
-
           fireEvent.click(getByText('취소'));
 
           expect(handleApplyCancel).not.toBeCalled();
@@ -186,8 +182,13 @@ describe('ApplicantViewButton', () => {
         };
 
         context('Click confirm Study participation application', () => {
-          it('renders modal window appears and application failure message', () => {
-            const { container, getByText } = renderApplicantViewButton({ group, time, user: 'user' });
+          const textareaFixtures = [
+            { label: '신청하게 된 이유', name: 'reason', value: '내용' },
+            { label: '스터디를 통해 얻고 싶은 것은 무엇인가요?', name: 'wantToGet', value: '내용' },
+          ];
+
+          it('renders modal window appears and application failure message', async () => {
+            const { container, getByText, getByLabelText } = renderApplicantViewButton({ group, time, user: 'user' });
 
             const button = getByText('신청하기');
 
@@ -195,7 +196,15 @@ describe('ApplicantViewButton', () => {
 
             fireEvent.click(button);
 
-            fireEvent.click(getByText('확인'));
+            textareaFixtures.forEach(({ label, name, value }) => {
+              const textarea = getByLabelText(label);
+
+              fireEvent.change(textarea, { target: { name, value } });
+            });
+
+            await act(async () => {
+              fireEvent.submit(getByText('확인'));
+            });
 
             expect(handleApply).toBeCalled();
 
@@ -212,7 +221,6 @@ describe('ApplicantViewButton', () => {
             expect(button).not.toBeNull();
 
             fireEvent.click(button);
-
             fireEvent.click(getByText('취소'));
 
             expect(handleApply).not.toBeCalled();
@@ -243,7 +251,6 @@ describe('ApplicantViewButton', () => {
           fireEvent.click(button);
 
           expect(handleApply).not.toBeCalled();
-
           expect(container).toHaveTextContent('로그인 후 신청 가능합니다.');
 
           fireEvent.click(getByText('확인'));

--- a/src/components/introduce/modals/ApplicationFormModal.jsx
+++ b/src/components/introduce/modals/ApplicationFormModal.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useCallback } from 'react';
-
-import _ from 'lodash';
+import React from 'react';
 
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+
+import { useForm } from 'react-hook-form';
 
 import { APPLY_FORM_TITLE, BUTTON_NAME } from '../../../util/constants/constants';
 
@@ -121,39 +121,20 @@ const BooksIcon = styled(BooksSvg)`
   })};
 `;
 
-const ApplicationFormModal = ({
-  visible, onCancel, onConfirm, onChangeApply, fields,
-}) => {
-  const [error, setError] = useState(null);
-
-  const { reason, wantToGet } = fields;
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-
-    setError(null);
-    onChangeApply({ name, value });
-  };
+const ApplicationFormModal = ({ visible, onCancel, onSubmit }) => {
+  const {
+    register, handleSubmit, formState: { errors }, reset,
+  } = useForm();
 
   const handleCancel = () => {
-    setError(null);
     onCancel();
+    reset();
   };
 
-  const handleConfirm = useCallback(() => {
-    if (!_.trim(reason)) {
-      setError('reason');
-      return;
-    }
-
-    if (!_.trim(wantToGet)) {
-      setError('wantToGet');
-      return;
-    }
-
-    setError(null);
-    onConfirm();
-  }, [reason, wantToGet, onConfirm]);
+  const formSubmitHandler = (formData) => {
+    onSubmit(formData);
+    reset();
+  };
 
   if (!visible) {
     return null;
@@ -168,34 +149,32 @@ const ApplicationFormModal = ({
             스터디 참여 신청서
           </h2>
         </HeaderWrapper>
-        <ContentBoxWrapper>
-          <label htmlFor="apply-reason">{APPLY_REASON}</label>
-          <Textarea
-            error={error && error === 'reason'}
-            rows="10"
-            id="apply-reason"
-            name="reason"
-            placeholder="내용을 입력해주세요."
-            value={reason}
-            onChange={handleChange}
-          />
-        </ContentBoxWrapper>
-        <ContentBoxWrapper>
-          <label htmlFor="study-want">{WANT_TO_GET}</label>
-          <Textarea
-            error={error && error === 'wantToGet'}
-            rows="10"
-            id="study-want"
-            name="wantToGet"
-            placeholder="내용을 입력해주세요."
-            value={wantToGet}
-            onChange={handleChange}
-          />
-        </ContentBoxWrapper>
-        <div className="buttons">
-          <StyledButton onClick={handleCancel}>{CANCEL}</StyledButton>
-          <StyledButton success onClick={handleConfirm}>{CONFIRM}</StyledButton>
-        </div>
+        <form onSubmit={handleSubmit(formSubmitHandler)}>
+          <ContentBoxWrapper>
+            <label htmlFor="apply-reason">{APPLY_REASON}</label>
+            <Textarea
+              rows="10"
+              id="apply-reason"
+              placeholder="내용을 입력해주세요."
+              error={errors?.reason}
+              {...register('reason', { required: true })}
+            />
+          </ContentBoxWrapper>
+          <ContentBoxWrapper>
+            <label htmlFor="study-want">{WANT_TO_GET}</label>
+            <Textarea
+              rows="10"
+              id="study-want"
+              placeholder="내용을 입력해주세요."
+              error={errors?.wantToGet}
+              {...register('wantToGet', { required: true })}
+            />
+          </ContentBoxWrapper>
+          <div className="buttons">
+            <StyledButton type="button" onClick={handleCancel}>{CANCEL}</StyledButton>
+            <StyledButton type="submit" success>{CONFIRM}</StyledButton>
+          </div>
+        </form>
       </ModalBoxWrapper>
     </ApplicationFormModalWrapper>
   );

--- a/src/containers/introduce/IntroduceHeaderContainer.jsx
+++ b/src/containers/introduce/IntroduceHeaderContainer.jsx
@@ -6,13 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useMediaQuery } from 'react-responsive';
 
 import { getAuth, getGroup } from '../../util/utils';
-import {
-  changeApplyFields,
-  clearApplyFields,
-  deleteParticipant,
-  updateConfirmParticipant,
-  updateParticipant,
-} from '../../reducers/groupSlice';
+import { deleteParticipant, updateConfirmParticipant, updateParticipant } from '../../reducers/groupSlice';
 
 import IntroduceHeader from '../../components/introduce/IntroduceHeader';
 import ApplicantViewButton from '../../components/introduce/ApplicantViewButton';
@@ -34,24 +28,15 @@ const IntroduceHeaderContainer = () => {
 
   const user = useSelector(getAuth('user'));
   const group = useSelector(getGroup('group'));
-  const applyFields = useSelector(getGroup('applyFields'));
 
   useInterval(() => setRealTime(Date.now()), 1000);
 
-  const onApplyStudy = useCallback(({ reason, wantToGet }) => {
-    dispatch(updateParticipant({ reason, wantToGet }));
+  const onApplyStudy = useCallback((formData) => {
+    dispatch(updateParticipant(formData));
   }, [dispatch]);
 
   const onApplyCancel = useCallback(() => {
     dispatch(deleteParticipant());
-  }, [dispatch]);
-
-  const onChangeApplyFields = useCallback(({ name, value }) => {
-    dispatch(changeApplyFields({ name, value }));
-  }, [dispatch]);
-
-  const clearApplyForm = useCallback(() => {
-    dispatch(clearApplyFields());
   }, [dispatch]);
 
   const onUpdateConfirmParticipant = useCallback((id) => {
@@ -73,11 +58,8 @@ const IntroduceHeaderContainer = () => {
         user={user}
         group={group}
         realTime={realTime}
-        applyFields={applyFields}
         onApply={onApplyStudy}
         onApplyCancel={onApplyCancel}
-        clearForm={clearApplyForm}
-        onChangeApplyFields={onChangeApplyFields}
       />
       <ModeratorViewButton
         user={user}

--- a/src/containers/introduce/IntroduceHeaderContainer.test.jsx
+++ b/src/containers/introduce/IntroduceHeaderContainer.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { act } from 'react-dom/test-utils';
 import { fireEvent, render } from '@testing-library/react';
 
 import { twoSecondsLater, tomorrow } from '../../util/utils';
@@ -26,7 +27,6 @@ describe('IntroduceHeaderContainer', () => {
       },
       groupReducer: {
         group: given.group,
-        applyFields: given.applyFields,
       },
     }));
   });
@@ -53,10 +53,6 @@ describe('IntroduceHeaderContainer', () => {
         'Algorithm',
       ],
     }));
-    given('applyFields', () => ({
-      reason: '',
-      wantToGet: '',
-    }));
 
     it('renders study group title', () => {
       const { container } = renderIntroduceHeaderContainer();
@@ -67,10 +63,6 @@ describe('IntroduceHeaderContainer', () => {
 
   context('without group ', () => {
     given('group', () => (null));
-    given('applyFields', () => ({
-      reason: '',
-      wantToGet: '',
-    }));
 
     it('Nothing renders group contents', () => {
       const { container } = renderIntroduceHeaderContainer();
@@ -80,64 +72,37 @@ describe('IntroduceHeaderContainer', () => {
   });
 
   context('When the logged-in user is not the author', () => {
+    const textareaFixtures = [
+      { label: '신청하게 된 이유', name: 'reason', value: '내용' },
+      { label: '스터디를 통해 얻고 싶은 것은 무엇인가요?', name: 'wantToGet', value: '내용' },
+    ];
+
     context('with group & user', () => {
       given('group', () => (STUDY_GROUP));
       given('user', () => ('user'));
-      given('applyFields', () => ({
-        reason: 'reason',
-        wantToGet: 'wantToGet',
-      }));
 
-      it('click event dispatches action call updateParticipant', () => {
-        const { getByText } = renderIntroduceHeaderContainer();
-
-        const button = getByText('신청하기');
-
-        expect(button).not.toBeNull();
-
-        fireEvent.click(button);
-
-        fireEvent.click(getByText('확인'));
-
-        expect(dispatch).toBeCalledTimes(1);
-      });
-
-      it('dispatches action calls changeApplyFields', () => {
-        const form = {
-          name: 'reason',
-          value: '내용',
-        };
-
+      it('click event dispatches action call updateParticipant', async () => {
         const { getByText, getByLabelText } = renderIntroduceHeaderContainer();
 
         const button = getByText('신청하기');
 
-        fireEvent.click(button);
-
-        const input = getByLabelText('신청하게 된 이유');
-
-        fireEvent.change(input, { target: form });
-
-        expect(dispatch).toBeCalledWith({
-          type: 'group/changeApplyFields',
-          payload: form,
-        });
-      });
-
-      it('click cancel dispatches call action clearApplyFields', () => {
-        const { getByText } = renderIntroduceHeaderContainer();
-
-        const button = getByText('신청하기');
-
         expect(button).not.toBeNull();
 
         fireEvent.click(button);
 
-        fireEvent.click(getByText('취소'));
+        textareaFixtures.forEach(({ label, name, value }) => {
+          const textarea = getByLabelText(label);
 
-        expect(dispatch).toBeCalledWith({
-          type: 'group/clearApplyFields',
+          fireEvent.change(textarea, { target: { name, value } });
+
+          expect(textarea).toHaveValue(value);
         });
+
+        await act(async () => {
+          fireEvent.submit(getByText('확인'));
+        });
+
+        expect(dispatch).toBeCalledTimes(1);
       });
     });
 
@@ -155,10 +120,6 @@ describe('IntroduceHeaderContainer', () => {
 
       given('group', () => (group));
       given('user', () => ('user'));
-      given('applyFields', () => ({
-        reason: '',
-        wantToGet: '',
-      }));
 
       context('click confirm', () => {
         it('click event dispatches action call deleteParticipant', () => {
@@ -210,10 +171,6 @@ describe('IntroduceHeaderContainer', () => {
       ],
     }));
     given('user', () => ('user2'));
-    given('applyFields', () => ({
-      reason: '',
-      wantToGet: '',
-    }));
 
     describe('Click "Approve to participate in the study" button and then click "Approve" button', () => {
       it('dispatches call action "updateConfirmParticipant"', () => {

--- a/src/reducers/groupSlice.js
+++ b/src/reducers/groupSlice.js
@@ -27,11 +27,6 @@ const writeInitialState = {
   tags: [],
 };
 
-const applyInitialState = {
-  reason: '',
-  wantToGet: '',
-};
-
 const { actions, reducer } = createSlice({
   name: 'group',
   initialState: {
@@ -41,7 +36,6 @@ const { actions, reducer } = createSlice({
     groupError: null,
     originalArticleId: null,
     writeField: writeInitialState,
-    applyFields: applyInitialState,
   },
 
   reducers: {
@@ -89,19 +83,6 @@ const { actions, reducer } = createSlice({
       };
     },
 
-    changeApplyFields(state, { payload: { name, value } }) {
-      return produce(state, (draft) => {
-        draft.applyFields[name] = value;
-      });
-    },
-
-    clearApplyFields(state) {
-      return {
-        ...state,
-        applyFields: applyInitialState,
-      };
-    },
-
     setOriginalArticle(state, { payload: fields }) {
       const {
         title, contents, applyEndDate, tags, personnel, id,
@@ -138,8 +119,6 @@ export const {
   changeWriteField,
   clearWriteFields,
   successWrite,
-  changeApplyFields,
-  clearApplyFields,
   setOriginalArticle,
   setGroupReview,
 } = actions;
@@ -203,14 +182,13 @@ export const editStudyGroup = (id) => async (dispatch, getState) => {
   }
 };
 
-export const updateParticipant = ({ reason, wantToGet }) => async (dispatch, getState) => {
+export const updateParticipant = (formData) => async (dispatch, getState) => {
   const { groupReducer: { group }, authReducer: { user } } = getState();
 
   const userInfo = {
     id: user,
-    reason,
-    wantToGet,
     confirm: false,
+    ...formData,
   };
 
   const newGroup = produce(group, (draft) => {
@@ -223,7 +201,6 @@ export const updateParticipant = ({ reason, wantToGet }) => async (dispatch, get
   });
 
   dispatch(setStudyGroup(newGroup));
-  dispatch(clearApplyFields());
 };
 
 export const deleteParticipant = () => async (dispatch, getState) => {

--- a/src/reducers/groupSlice.test.js
+++ b/src/reducers/groupSlice.test.js
@@ -14,8 +14,6 @@ import reducer, {
   successWrite,
   updateParticipant,
   deleteParticipant,
-  changeApplyFields,
-  clearApplyFields,
   updateConfirmParticipant,
   deleteGroup,
   setOriginalArticle,
@@ -56,10 +54,6 @@ describe('reducer', () => {
         participants: [],
         personnel: '1',
         tags: [],
-      },
-      applyFields: {
-        reason: '',
-        wantToGet: '',
       },
     };
 
@@ -162,41 +156,41 @@ describe('reducer', () => {
     });
   });
 
-  describe('changeApplyFields', () => {
-    it('changes a field of study participation application form', () => {
-      const initialState = {
-        applyFields: {
-          reason: '',
-          wantToGet: '',
-        },
-      };
+  // describe('changeApplyFields', () => {
+  //   it('changes a field of study participation application form', () => {
+  //     const initialState = {
+  //       applyFields: {
+  //         reason: '',
+  //         wantToGet: '',
+  //       },
+  //     };
 
-      const state = reducer(
-        initialState,
-        changeApplyFields({ name: 'reason', value: '참여합니다.' }),
-      );
+  //     const state = reducer(
+  //       initialState,
+  //       changeApplyFields({ name: 'reason', value: '참여합니다.' }),
+  //     );
 
-      expect(state.applyFields.reason).toBe('참여합니다.');
-    });
-  });
+  //     expect(state.applyFields.reason).toBe('참여합니다.');
+  //   });
+  // });
 
-  describe('clearApplyFields', () => {
-    const initialState = {
-      applyFields: {
-        reason: '타이틀',
-        wantToGet: '내용',
-      },
-    };
+  // describe('clearApplyFields', () => {
+  //   const initialState = {
+  //     applyFields: {
+  //       reason: '타이틀',
+  //       wantToGet: '내용',
+  //     },
+  //   };
 
-    it('clears fields of application', () => {
-      const state = reducer(initialState, clearApplyFields());
+  //   it('clears fields of application', () => {
+  //     const state = reducer(initialState, clearApplyFields());
 
-      const { applyFields: { reason, wantToGet } } = state;
+  //     const { applyFields: { reason, wantToGet } } = state;
 
-      expect(reason).toBe('');
-      expect(wantToGet).toBe('');
-    });
-  });
+  //     expect(reason).toBe('');
+  //     expect(wantToGet).toBe('');
+  //   });
+  // });
 
   describe('setOriginalArticle', () => {
     const initialState = {
@@ -451,7 +445,6 @@ describe('async actions', () => {
           confirm: false,
         }],
       }));
-      expect(actions[1]).toEqual(clearApplyFields());
     });
   });
 

--- a/src/reducers/groupSlice.test.js
+++ b/src/reducers/groupSlice.test.js
@@ -156,42 +156,6 @@ describe('reducer', () => {
     });
   });
 
-  // describe('changeApplyFields', () => {
-  //   it('changes a field of study participation application form', () => {
-  //     const initialState = {
-  //       applyFields: {
-  //         reason: '',
-  //         wantToGet: '',
-  //       },
-  //     };
-
-  //     const state = reducer(
-  //       initialState,
-  //       changeApplyFields({ name: 'reason', value: '참여합니다.' }),
-  //     );
-
-  //     expect(state.applyFields.reason).toBe('참여합니다.');
-  //   });
-  // });
-
-  // describe('clearApplyFields', () => {
-  //   const initialState = {
-  //     applyFields: {
-  //       reason: '타이틀',
-  //       wantToGet: '내용',
-  //     },
-  //   };
-
-  //   it('clears fields of application', () => {
-  //     const state = reducer(initialState, clearApplyFields());
-
-  //     const { applyFields: { reason, wantToGet } } = state;
-
-  //     expect(reason).toBe('');
-  //     expect(wantToGet).toBe('');
-  //   });
-  // });
-
   describe('setOriginalArticle', () => {
     const initialState = {
       originalArticleId: null,

--- a/src/styles/Textarea.jsx
+++ b/src/styles/Textarea.jsx
@@ -51,8 +51,8 @@ const TextareaWrapper = styled.textarea`
   `};
 `;
 
-const Textarea = (props) => (
-  <TextareaWrapper {...props} />
-);
+const Textarea = React.forwardRef((props, ref) => (
+  <TextareaWrapper {...props} ref={ref} />
+));
 
 export default Textarea;


### PR DESCRIPTION
- 전역으로 관리되던 신청서 폼을 react-hook-form을 사용하여 걷어냄
- eslint `react/jsx-props-no-spreading`에 `Textarea` 예외 추가
- 불필요한 `onChange` event 삭제