### PR TITLE
[Improve] 기존에 있던 각자 redirect를 PrivateRoute로 구현하라

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19437,6 +19437,21 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-star-ratings": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-star-ratings/-/react-star-ratings-2.3.0.tgz",
@@ -19459,6 +19474,31 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/react-toggle": {
       "version": "4.1.2",
@@ -40172,6 +40212,18 @@
         "tiny-warning": "^1.0.0"
       }
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
     "react-star-ratings": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-star-ratings/-/react-star-ratings-2.3.0.tgz",
@@ -40191,6 +40243,30 @@
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2"
           }
+        }
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,15 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Switch, Route } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 
 import { ThemeProvider } from '@emotion/react';
 
 import useTheme from './hooks/useTheme';
 
-import { loadItem } from './services/storage';
-import { setUser } from './reducers/authSlice';
-
 import { lightTheme, darkTheme } from './styles/theme';
 
 import ErrorBoundary from './ErrorBoundary';
+import PrivateRoute from './components/common/PrivateRoute';
 
 import MainPage from './pages/MainPage';
 import WritePage from './pages/WritePage';
@@ -23,18 +20,7 @@ import GlobalStyles from './styles/GlobalStyles';
 import IntroducePage from './pages/IntroducePage';
 
 const App = () => {
-  const dispatch = useDispatch();
   const { theme } = useTheme();
-
-  const user = loadItem('user');
-
-  useEffect(() => {
-    if (user) {
-      const { email } = user;
-
-      dispatch(setUser(email));
-    }
-  }, [dispatch, user]);
 
   return (
     <ThemeProvider theme={theme ? darkTheme : lightTheme}>
@@ -43,7 +29,7 @@ const App = () => {
         <Switch>
           <Route exact path="/" component={MainPage} />
           <Route exact path="/introduce/:id" component={IntroducePage} />
-          <Route path="/write" component={WritePage} />
+          <PrivateRoute path="/write" component={WritePage} />
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route component={NotFoundPage} />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { render } from '@testing-library/react';
 
-import { loadItem } from './services/storage';
 import { lightTheme, darkTheme } from './styles/theme';
 
 import STUDY_GROUPS from '../fixtures/study-groups';
@@ -14,7 +13,6 @@ import App from './App';
 import InjectMockProviders from './components/common/test/InjectMockProviders';
 
 jest.mock('react-redux');
-jest.mock('./services/storage');
 
 describe('App', () => {
   const dispatch = jest.fn();
@@ -141,25 +139,6 @@ describe('App', () => {
       const { container } = renderApp({ path: '/register' });
 
       expect(container).toHaveTextContent('회원가입');
-    });
-  });
-
-  context('when logged in', () => {
-    const user = {
-      email: 'seungmin@naver.com',
-    };
-
-    beforeEach(() => {
-      loadItem.mockImplementation(() => user);
-    });
-
-    it('calls dispatch with "setUser" action', () => {
-      renderApp({ path: '/' });
-
-      expect(dispatch).toBeCalledWith({
-        type: 'auth/setUser',
-        payload: user.email,
-      });
     });
   });
 });

--- a/src/components/common/PrivateRoute.jsx
+++ b/src/components/common/PrivateRoute.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+import { Route, Redirect } from 'react-router-dom';
+
+import { getAuth } from '../../util/utils';
+
+const PrivateRoute = ({ component: Component, ...rest }) => {
+  const user = useSelector(getAuth('user'));
+
+  return (
+    <Route
+      {...rest}
+      render={(props) => (user ? (
+        <Component {...props} />
+      ) : (
+        <Redirect to={{
+          pathname: '/login',
+          state: { from: props.location },
+        }}
+        />
+      ))}
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/src/components/common/PrivateRoute.test.jsx
+++ b/src/components/common/PrivateRoute.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import PrivateRoute from './PrivateRoute';
+
+jest.mock('react-redux');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Redirect: jest.fn(({ to: { pathname } }) => (`Redirected to ${pathname}`)),
+}));
+
+describe('PrivateRoute', () => {
+  const renderPrivateRoute = ({ component }) => render((
+    <MemoryRouter>
+      <PrivateRoute
+        component={component}
+      />
+    </MemoryRouter>
+  ));
+
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      authReducer: {
+        user: given.user,
+      },
+    }));
+  });
+
+  context('with user', () => {
+    given('user', () => 'mockUser');
+    const MockComponent = () => (
+      <h1>정상입니다!</h1>
+    );
+
+    it('renders component TextContent "정상입니다!"', () => {
+      const { container } = renderPrivateRoute({
+        component: MockComponent,
+      });
+
+      expect(container).toHaveTextContent('정상입니다');
+    });
+  });
+
+  context('without user', () => {
+    given('user', () => null);
+    const MockComponent = () => (
+      <h1>실패입니다!</h1>
+    );
+
+    it('redirect to "/login"', () => {
+      const { container } = renderPrivateRoute({
+        component: MockComponent,
+      });
+
+      expect(container).toHaveTextContent('Redirected to /login');
+    });
+  });
+});

--- a/src/containers/write/WriteButtonsContainer.jsx
+++ b/src/containers/write/WriteButtonsContainer.jsx
@@ -4,7 +4,7 @@ import { useUnmount } from 'react-use';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { getAuth, getGroup } from '../../util/utils';
+import { getGroup } from '../../util/utils';
 import { clearWriteFields, editStudyGroup, writeStudyGroup } from '../../reducers/groupSlice';
 
 import WriteButtons from '../../components/write/WriteButtons';
@@ -13,17 +13,10 @@ const WriteButtonsContainer = () => {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const user = useSelector(getAuth('user'));
   const groupId = useSelector(getGroup('groupId'));
   const groupError = useSelector(getGroup('groupError'));
   const writeField = useSelector(getGroup('writeField'));
   const originalArticleId = useSelector(getGroup('originalArticleId'));
-
-  useEffect(() => {
-    if (!user) {
-      history.push('/');
-    }
-  }, [user, history]);
 
   const onSubmit = () => {
     if (originalArticleId) {

--- a/src/containers/write/WriteButtonsContainer.test.jsx
+++ b/src/containers/write/WriteButtonsContainer.test.jsx
@@ -148,29 +148,6 @@ describe('WriteButtonsContainer', () => {
           });
         });
       });
-
-      context('without user', () => {
-        given('user', () => (null));
-
-        given('writeField', () => ({
-          title: '123',
-          contents: '우리는 이것저것 합니다.1',
-          moderatorId: 'user1',
-          applyEndDate: '2020-10-01',
-          participants: [],
-          personnel: '1',
-          tags: [
-            'javascript',
-            'react',
-          ],
-        }));
-
-        it('go to redirection main page', () => {
-          renderWriteButtonsContainer();
-
-          expect(mockPush).toBeCalledWith('/');
-        });
-      });
     });
   });
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,10 @@ import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 
 import store from './reducers/store';
+import { setUser } from './reducers/authSlice';
+
 import { isDevLevel } from './util/utils';
+import { loadItem } from './services/storage';
 
 import App from './App';
 
@@ -20,6 +23,20 @@ Sentry.init({
   environment: process.env.NODE_ENV,
   tracesSampleRate: 1.0,
 });
+
+const loadUser = () => {
+  const user = loadItem('user');
+
+  if (!user) {
+    return;
+  }
+
+  const { email } = user;
+
+  store.dispatch(setUser(email));
+};
+
+loadUser();
 
 ReactDOM.render(
   (


### PR DESCRIPTION
- 유저정보를 불러오는 loadUser를 App.jsx에서 index로 변경
    - 순간적으로 redux store에 담기기전에 컴포넌트 로직이 실행됨에 따라 엉뚱하게 redirect되는 현상 수정
- 기존에 존재하던 Redirect로직 삭제