### PR TITLE
[Feature] 내 정보 페이지의 회원 탈퇴를 로직을 구현하라

### DIFF
--- a/src/components/myInfo/ProfileSettingForm.jsx
+++ b/src/components/myInfo/ProfileSettingForm.jsx
@@ -1,43 +1,70 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import Button from '../../styles/Button';
+import AskMembershipWithdrawal from './modal/AskMembershipWithdrawal';
 
 const ProfileDetailFormWrapper = styled.div`
 
 `;
 
-const ProfileDetailForm = ({ user, onSendEmailVerification, onSendPasswordResetEmail }) => (
-  <ProfileDetailFormWrapper>
-    <div>
-      {`이메일: ${user.email}`}
-      {user.emailVerified ? (
-        <div> 이메일 인증 완료 </div>
-      ) : (
-        <Button
-          onClick={onSendEmailVerification}
-        >
-          이메일 인증 하기
-        </Button>
-      )}
-    </div>
-    <div>
-      {`별명: ${user.displayName || user.email}`}
-    </div>
-    <div>
-      {`프로필: ${user.photoURL || '없음'} `}
-    </div>
-    <Button
-      success
-      onClick={onSendPasswordResetEmail}
-    >
-      비밀번호 재설정
-    </Button>
-    <Button warn>
-      회원 탈퇴
-    </Button>
-  </ProfileDetailFormWrapper>
-);
+const ProfileDetailForm = ({
+  user,
+  onMembershipWithdrawal,
+  onSendEmailVerification,
+  onSendPasswordResetEmail,
+}) => {
+  const [modal, setModal] = useState(false);
+
+  const handleClickDeleteUser = () => setModal(true);
+
+  const handleCancel = () => setModal(false);
+
+  const handleConfirm = () => {
+    setModal(false);
+    onMembershipWithdrawal();
+  };
+
+  return (
+    <ProfileDetailFormWrapper>
+      <div>
+        {`이메일: ${user.email}`}
+        {user.emailVerified ? (
+          <div> 이메일 인증 완료 </div>
+        ) : (
+          <Button
+            onClick={onSendEmailVerification}
+          >
+            이메일 인증 하기
+          </Button>
+        )}
+      </div>
+      <div>
+        {`별명: ${user.displayName || user.email}`}
+      </div>
+      <div>
+        {`프로필: ${user.photoURL || '없음'} `}
+      </div>
+      <Button
+        success
+        onClick={onSendPasswordResetEmail}
+      >
+        비밀번호 재설정
+      </Button>
+      <Button
+        warn
+        onClick={handleClickDeleteUser}
+      >
+        회원 탈퇴
+      </Button>
+      <AskMembershipWithdrawal
+        visible={modal}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+      />
+    </ProfileDetailFormWrapper>
+  );
+};
 
 export default ProfileDetailForm;

--- a/src/components/myInfo/ProfileSettingForm.test.jsx
+++ b/src/components/myInfo/ProfileSettingForm.test.jsx
@@ -1,44 +1,29 @@
 import React from 'react';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import { render, fireEvent } from '@testing-library/react';
 
 import ProfileSettingForm from './ProfileSettingForm';
+import InjectMockProviders from '../common/test/InjectMockProviders';
 
 describe('ProfileSettingForm', () => {
   const handleSendEmailVerification = jest.fn();
   const handleSendPasswordReset = jest.fn();
+  const handleMembershipWithdrawal = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   const renderProfileSettingForm = () => render((
-    <MemoryRouter>
+    <InjectMockProviders>
       <ProfileSettingForm
         user={given.user}
-        onSendEmailVerification={handleSendEmailVerification}
         onSendPasswordResetEmail={handleSendPasswordReset}
+        onMembershipWithdrawal={handleMembershipWithdrawal}
+        onSendEmailVerification={handleSendEmailVerification}
       />
-    </MemoryRouter>
+    </InjectMockProviders>
   ));
-
-  describe('render profile detail form', () => {
-    it('render reset password button and withdrawal', () => {
-      given('user', () => ({
-        email: 'test@test.com',
-        emailVerified: false,
-        displayName: null,
-        photoURL: null,
-      }));
-
-      const { container } = renderProfileSettingForm();
-
-      expect(container).toHaveTextContent('비밀번호 재설정');
-      expect(container).toHaveTextContent('회원 탈퇴');
-    });
-  });
 
   describe('When click "비밀번호 재설정" button', () => {
     given('user', () => ({
@@ -54,6 +39,47 @@ describe('ProfileSettingForm', () => {
       fireEvent.click(getByText('비밀번호 재설정'));
 
       expect(handleSendPasswordReset).toBeCalledTimes(1);
+    });
+  });
+
+  describe('When click "회원 탈퇴" button', () => {
+    given('user', () => ({
+      email: 'test@test.com',
+      emailVerified: false,
+      displayName: null,
+      photoURL: null,
+    }));
+
+    it('should visible ask membership withdrawal', () => {
+      const { getByText, container } = renderProfileSettingForm();
+
+      fireEvent.click(getByText('회원 탈퇴'));
+
+      expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
+    });
+
+    describe('Click membership withdrawal modal confirm button', () => {
+      it('should call membership withdrawal', () => {
+        const { getByText } = renderProfileSettingForm();
+
+        fireEvent.click(getByText('회원 탈퇴'));
+
+        fireEvent.click(getByText('확인'));
+
+        expect(handleMembershipWithdrawal).toBeCalledTimes(1);
+      });
+    });
+
+    describe('Click membership withdrawal modal cancel button', () => {
+      it("shouldn't call membership withdrawal", () => {
+        const { getByText } = renderProfileSettingForm();
+
+        fireEvent.click(getByText('회원 탈퇴'));
+
+        fireEvent.click(getByText('취소'));
+
+        expect(handleMembershipWithdrawal).not.toBeCalled();
+      });
     });
   });
 

--- a/src/components/myInfo/modal/AskMembershipWithdrawal.jsx
+++ b/src/components/myInfo/modal/AskMembershipWithdrawal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import ModalWindow from '../../common/ModalWindow';
+
+const AskMembershipWithdrawal = ({ visible, onCancel, onConfirm }) => (
+  <ModalWindow
+    title="회원 탈퇴"
+    description="회원을 탈퇴하시겠습니까?"
+    visible={visible}
+    onConfirm={onConfirm}
+    onCancel={onCancel}
+  />
+);
+
+export default AskMembershipWithdrawal;

--- a/src/components/myInfo/modal/AskMembershipWithdrawal.test.jsx
+++ b/src/components/myInfo/modal/AskMembershipWithdrawal.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import MockTheme from '../../common/test/MockTheme';
+import AskMembershipWithdrawal from './AskMembershipWithdrawal';
+
+describe('AskMembershipWithdrawal', () => {
+  const handleCancel = jest.fn();
+  const handleConfirm = jest.fn();
+
+  const renderAskMembershipWithdrawal = ({ visible }) => render((
+    <MockTheme>
+      <AskMembershipWithdrawal
+        visible={visible}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </MockTheme>
+  ));
+
+  context('with visible', () => {
+    const modal = {
+      visible: true,
+    };
+
+    it('renders Modal text', () => {
+      const { container } = renderAskMembershipWithdrawal(modal);
+
+      expect(container).toHaveTextContent('회원 탈퇴');
+      expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
+    });
+
+    it('calls confirm event action', () => {
+      const { getByText } = renderAskMembershipWithdrawal(modal);
+
+      const button = getByText('확인');
+
+      fireEvent.click(button);
+
+      expect(handleConfirm).toBeCalled();
+    });
+
+    it('calls cancel event action', () => {
+      const { getByText } = renderAskMembershipWithdrawal(modal);
+
+      const button = getByText('취소');
+
+      fireEvent.click(button);
+
+      expect(handleCancel).toBeCalled();
+    });
+  });
+
+  context('without visible', () => {
+    const modal = {
+      visible: false,
+    };
+
+    it("doesn't renders Modal text", () => {
+      const { container } = renderAskMembershipWithdrawal(modal);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/containers/myInfo/ProfileSettingContainer.jsx
+++ b/src/containers/myInfo/ProfileSettingContainer.jsx
@@ -7,7 +7,9 @@ import { toast } from 'react-toastify';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getAuth } from '../../util/utils';
-import { requestEmailVerification, clearAuth, requestResetPassword } from '../../reducers/authSlice';
+import {
+  requestEmailVerification, clearAuth, requestResetPassword, requestDeleteUser,
+} from '../../reducers/authSlice';
 import { FIREBASE_AUTH_ERROR_MESSAGE, ERROR_MESSAGE } from '../../util/constants/messages';
 
 import ProfileSettingForm from '../../components/myInfo/ProfileSettingForm';
@@ -29,6 +31,11 @@ const ProfileSettingContainer = ({ user }) => {
 
   const onClickSendPasswordResetEmail = useCallback(
     () => dispatch(requestResetPassword()),
+    [dispatch],
+  );
+
+  const onClickMembershipWithdrawal = useCallback(
+    () => dispatch(requestDeleteUser()),
     [dispatch],
   );
 
@@ -58,6 +65,7 @@ const ProfileSettingContainer = ({ user }) => {
     <ProfileSettingContainerWrapper>
       <ProfileSettingForm
         user={user}
+        onMembershipWithdrawal={onClickMembershipWithdrawal}
         onSendEmailVerification={onClickSendEmailVerification}
         onSendPasswordResetEmail={onClickSendPasswordResetEmail}
       />

--- a/src/containers/myInfo/ProfileSettingContainer.test.jsx
+++ b/src/containers/myInfo/ProfileSettingContainer.test.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { render, fireEvent, screen } from '@testing-library/react';
 
 import ProfileSettingContainer from './ProfileSettingContainer';
+import InjectMockProviders from '../../components/common/test/InjectMockProviders';
 
 describe('ProfileSettingContainer', () => {
   const dispatch = jest.fn();
@@ -23,9 +24,11 @@ describe('ProfileSettingContainer', () => {
   });
 
   const renderProfileSettingContainer = (user) => render((
-    <ProfileSettingContainer
-      user={user}
-    />
+    <InjectMockProviders>
+      <ProfileSettingContainer
+        user={user}
+      />
+    </InjectMockProviders>
   ));
 
   context('with user', () => {
@@ -60,6 +63,28 @@ describe('ProfileSettingContainer', () => {
         fireEvent.click(getByText(/비밀번호 재설정/i));
 
         expect(dispatch).toBeCalledTimes(1);
+      });
+    });
+
+    describe('Click membership withdrawal button', () => {
+      it('should visible ask membership withdrawal modal', () => {
+        const { getByText, container } = renderProfileSettingContainer(currentUser);
+
+        fireEvent.click(getByText(/회원 탈퇴/i));
+
+        expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
+      });
+
+      describe('Click membership withdrawal modal confirm button', () => {
+        it('should listen dispatch action event', () => {
+          const { getByText } = renderProfileSettingContainer(currentUser);
+
+          fireEvent.click(getByText(/회원 탈퇴/i));
+
+          fireEvent.click(getByText(/확인/i));
+
+          expect(dispatch).toBeCalledTimes(1);
+        });
       });
     });
 

--- a/src/reducers/authSlice.js
+++ b/src/reducers/authSlice.js
@@ -6,6 +6,8 @@ import {
   postUserRegister,
   sendEmailVerification,
   sendPasswordResetEmail,
+  deleteUser,
+  postReauthenticateWithCredential,
 } from '../services/api';
 
 import { isDevLevel } from '../util/utils';
@@ -115,6 +117,26 @@ export const requestResetPassword = () => async (dispatch, getState) => {
     await sendPasswordResetEmail(user);
 
     dispatch(setAuth(true));
+  } catch (error) {
+    dispatch(setAuthError(error.code));
+  }
+};
+
+export const requestDeleteUser = () => async (dispatch) => {
+  try {
+    await deleteUser();
+
+    removeItem('user');
+
+    dispatch(logout());
+  } catch (error) {
+    dispatch(setAuthError(error.code));
+  }
+};
+
+export const requestReauthenticateWithCredential = (password) => async (dispatch) => {
+  try {
+    await postReauthenticateWithCredential(password);
   } catch (error) {
     dispatch(setAuthError(error.code));
   }

--- a/src/reducers/authSlice.test.js
+++ b/src/reducers/authSlice.test.js
@@ -14,10 +14,18 @@ import reducer, {
   requestLogout,
   requestEmailVerification,
   requestResetPassword,
+  requestDeleteUser,
+  requestReauthenticateWithCredential,
 } from './authSlice';
 
 import {
-  postUserLogin, postUserLogout, postUserRegister, sendEmailVerification, sendPasswordResetEmail,
+  postUserLogin,
+  postUserLogout,
+  postUserRegister,
+  sendEmailVerification,
+  sendPasswordResetEmail,
+  deleteUser,
+  postReauthenticateWithCredential,
 } from '../services/api';
 
 const middlewares = [thunk];
@@ -290,6 +298,82 @@ describe('async actions', () => {
       it('fail to send password reset email', async () => {
         try {
           await store.dispatch(requestResetPassword());
+        } catch (error) {
+          const actions = store.getActions();
+
+          expect(actions[0]).toEqual({
+            payload: error,
+            type: 'auth/setAuthError',
+          });
+        }
+      });
+    });
+  });
+
+  describe('requestDeleteUser', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    context('without auth error', () => {
+      deleteUser.mockImplementationOnce(() => ({}));
+
+      it('dispatches requestDeleteUser action success to logout', async () => {
+        await store.dispatch(requestDeleteUser());
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual({
+          type: 'auth/logout',
+        });
+      });
+    });
+
+    context('with auth error', () => {
+      deleteUser.mockImplementationOnce(() => {
+        throw new Error('error');
+      });
+
+      it('fail to delete user', async () => {
+        try {
+          await store.dispatch(requestDeleteUser());
+        } catch (error) {
+          const actions = store.getActions();
+
+          expect(actions[0]).toEqual({
+            payload: error,
+            type: 'auth/setAuthError',
+          });
+        }
+      });
+    });
+  });
+
+  describe('requestReauthenticateWithCredential', () => {
+    const password = 'test';
+
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    context('without auth error', () => {
+      postReauthenticateWithCredential.mockImplementationOnce(() => ({}));
+
+      it('dispatches requestReauthenticateWithCredential action success', async () => {
+        await store.dispatch(requestReauthenticateWithCredential(password));
+
+        expect(postReauthenticateWithCredential).toBeCalledWith(password);
+      });
+    });
+
+    context('with auth error', () => {
+      postReauthenticateWithCredential.mockImplementationOnce(() => {
+        throw new Error('error');
+      });
+
+      it('dispatches action setAuthError', async () => {
+        try {
+          await store.dispatch(requestReauthenticateWithCredential(password));
         } catch (error) {
           const actions = store.getActions();
 

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -27,3 +27,7 @@ export const deletePostReview = jest.fn();
 export const sendEmailVerification = jest.fn();
 
 export const sendPasswordResetEmail = jest.fn();
+
+export const deleteUser = jest.fn();
+
+export const postReauthenticateWithCredential = jest.fn();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,5 @@
 import {
-  db, auth, fireStore, actionCodeSettings,
+  db, auth, fireStore, actionCodeSettings, authProvider,
 } from './firebase';
 
 import { isDevLevel } from '../util/utils';
@@ -147,4 +147,19 @@ export const sendPasswordResetEmail = async (email) => {
     email,
     actionCodeSettings(isDevLevel(process.env.NODE_ENV)),
   );
+};
+
+export const deleteUser = async () => {
+  await auth.currentUser.delete();
+};
+
+export const postReauthenticateWithCredential = async (password) => {
+  const user = auth.currentUser;
+
+  const credential = authProvider.EmailAuthProvider.credential(
+    user.email,
+    password,
+  );
+
+  await user.reauthenticateWithCredential(credential);
 };

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,4 +1,6 @@
-import { auth, db, fireStore } from './firebase';
+import {
+  auth, db, fireStore, authProvider,
+} from './firebase';
 
 import {
   postUserRegister,
@@ -16,6 +18,8 @@ import {
   updatePostParticipant,
   sendEmailVerification,
   sendPasswordResetEmail,
+  deleteUser,
+  postReauthenticateWithCredential,
 } from './api';
 
 import STUDY_GROUP from '../../fixtures/study-group';
@@ -226,7 +230,7 @@ describe('api', () => {
       };
     });
 
-    it('call sendEmailVerification api with dev level', async () => {
+    it('call sendEmailVerification api', async () => {
       await sendEmailVerification();
 
       expect(mockEmailVerification).toBeCalledWith({
@@ -250,6 +254,49 @@ describe('api', () => {
       expect(mockPasswordResetEmail).toBeCalledWith(email, {
         url: 'http://localhost:8080/myinfo/setting/?email=test@test.com',
       });
+    });
+  });
+
+  describe('deleteUser', () => {
+    const mockDeleteUser = jest.fn();
+
+    beforeEach(() => {
+      auth.currentUser = {
+        delete: mockDeleteUser,
+      };
+    });
+
+    it('call deleteUser api', async () => {
+      await deleteUser();
+
+      expect(mockDeleteUser).toBeCalledTimes(1);
+    });
+  });
+
+  describe('postReauthenticateWithCredential', () => {
+    const password = 'test';
+    const mockCredential = jest.fn().mockReturnValue({
+      email: 'test@test.com',
+      password,
+    });
+    const mockEeauthenticateWithCredential = jest.fn();
+
+    beforeEach(() => {
+      auth.currentUser = {
+        email: 'test@test.com',
+        reauthenticateWithCredential: mockEeauthenticateWithCredential,
+      };
+
+      authProvider.EmailAuthProvider = {
+        credential: mockCredential,
+      };
+    });
+
+    it('call postReauthenticateWithCredential api', async () => {
+      await postReauthenticateWithCredential(password);
+
+      expect(mockCredential).toBeCalledWith('test@test.com', password);
+      expect(mockEeauthenticateWithCredential).toBeCalledTimes(1);
     });
   });
 

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -15,6 +15,8 @@ export const db = firebase.firestore();
 
 export const auth = firebase.auth();
 
+export const authProvider = firebase.auth;
+
 export const actionCodeSettings = (isDevLevel) => {
   const { currentUser } = auth;
 


### PR DESCRIPTION
- 회원탈퇴 firebase API구현 및 리덕스 구현
- 회원탈퇴를 위한 사용자 재인증 API 로직 구현
- 내정보 페이지에 click 핸들러 구현
- 회원탈퇴 확인 모달 구현